### PR TITLE
start tracking coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install -r requirements.txt
 
 before_script: export PYTHONPATH=$PYTHONPATH:$(pwd)
-script: nosetests
+script: nosetests --with-coverage
 
 after_success: 
   - bash <(curl -s https://codecov.io/bash)  


### PR DESCRIPTION
## References
https://github.com/codecov/example-python#using-nosetests
http://nose.readthedocs.io/en/latest/plugins/cover.html

There is also [nose-cov](https://pypi.python.org/pypi/nose-cov) that I've used in the past. I believe it works better with multiprocessing.